### PR TITLE
Add mathlib4 as a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 .DS_Store
 build/
-lean_packages/*
-!/lean_packages/manifest.json/build
-/lean_packages/*
-!/lean_packages/manifest.json
+lake-packages/*
+!/lake-packages/manifest.json/build
+/lake-packages/*
+!/lake-packages/manifest.json
 /build
-/lean_packages/*
-!/lean_packages/manifest.json
+/lake-packages/*
+!/lake-packages/manifest.json
 prelude/build/

--- a/Katydid/Std/Lists.lean
+++ b/Katydid/Std/Lists.lean
@@ -467,7 +467,6 @@ theorem list_take_app_2 (n: Nat) (xs ys: List α):
       rw [Nat.add_comm (length xs) 1]
       rw [Nat.add_assoc]
       rw [Nat.add_comm]
-      rfl
     rw [hcomm]
     rw [take]
     apply (congrArg (cons x))

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -2,14 +2,38 @@
  "packagesDir": "lake-packages",
  "packages":
  [{"git":
+   {"url": "https://github.com/EdAyers/ProofWidgets4",
+    "subDir?": null,
+    "rev": "c43db94a8f495dad37829e9d7ad65483d68c86b8",
+    "name": "proofwidgets",
+    "inputRev?": "v0.0.11"}},
+  {"git":
+   {"url": "https://github.com/mhuisi/lean4-cli.git",
+    "subDir?": null,
+    "rev": "5a858c32963b6b19be0d477a30a1f4b6c120be7e",
+    "name": "Cli",
+    "inputRev?": "nightly"}},
+  {"git":
+   {"url": "https://github.com/leanprover-community/mathlib4",
+    "subDir?": null,
+    "rev": "f8c1566ccfded661bfcb7b64f01a88be3a9d87dc",
+    "name": "mathlib",
+    "inputRev?": null}},
+  {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
     "rev": "ae84bd82cca324dc958583d6f1ae08429877dcb0",
     "name": "Qq",
     "inputRev?": "master"}},
   {"git":
+   {"url": "https://github.com/JLimperg/aesop",
+    "subDir?": null,
+    "rev": "f04538ab6ad07642368cf11d2702acc0a9b4bcee",
+    "name": "aesop",
+    "inputRev?": "master"}},
+  {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "a9fdff6f20fdf200ae1070044f2a5479137e141b",
+    "rev": "dff883c55395438ae2a5c65ad5ddba084b600feb",
     "name": "std",
     "inputRev?": "main"}}]}

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,12 +4,12 @@
  [{"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
-    "rev": "c71f94e34c1cda52eef5c93dc9da409ab2727420",
+    "rev": "ae84bd82cca324dc958583d6f1ae08429877dcb0",
     "name": "Qq",
     "inputRev?": "master"}},
   {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "70b5bc3054838f789cec4b6f088a1ffebc5926b1",
+    "rev": "a9fdff6f20fdf200ae1070044f2a5479137e141b",
     "name": "std",
     "inputRev?": "main"}}]}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -6,5 +6,6 @@ package katydid
 @[default_target]
 lean_lib Katydid
 
-require std from git "https://github.com/leanprover/std4" @ "main"
-require Qq from git "https://github.com/gebner/quote4" @ "master"
+-- dependencies std4, quote4 are obtained transitively through mathlib4
+require mathlib from git
+  "https://github.com/leanprover-community/mathlib4"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-03-09
+leanprover/lean4:nightly-2023-07-12


### PR DESCRIPTION
This PR adds mathlib4 as a dependency, primarily so we can use MathLib.Tactic and perhaps the regular expression modules (see https://github.com/katydid/proofs/issues/55).

### Remote caching

Run `lake exe cache get` in the root of the repository to download the cached build of MathLib. This will make builds/ide interaction quicker.

### std4 and quote4 dependencies

The mathlib4 documentation recommends we obtain `std4` and `quote4` dependencies transitively, so that the remote build cache works properly.

See: https://github.com/leanprover-community/mathlib4/wiki/Using-mathlib4-as-a-dependency/712f7e92c5a68ab4b8601192f86e3c8ae0dc7f33#more-on-lake-exe-cache

### lean-toolchain

To use mathlib4 we must keep the `lean-toolchain` file synchronised with their repository, this PR updates this. I used:

```
curl -L https://raw.githubusercontent.com/leanprover-community/mathlib4/master/lean-toolchain -o lean-toolchain
```

### Importing the library

Importing the library has the side-effect of updating the `simp` database. This means our existing code breaks with "goal already completed" errors.  