### PR TITLE
Introducing linarith

### DIFF
--- a/Katydid.lean
+++ b/Katydid.lean
@@ -1,6 +1,3 @@
-import Katydid.Std.Algebra
-import Katydid.Std.Ordering
-import Katydid.Std.ThunkOrdering
 import Katydid.Std.Lists
 import Katydid.Std.Ltac
 import Katydid.Std.Balistic

--- a/Katydid/Std/Algebra.lean
+++ b/Katydid/Std/Algebra.lean
@@ -4,15 +4,15 @@ class Magma (α : Type u) where
 infixl:65 " ∘ " => Magma.op
 
 class Semigroup (G : Type u) extends Magma G where
-  is_assoc : ∀ a b c : G, op (op a b) c = op a (op b c)
+  is_assoc : ∀ a b c : G, (a ∘ b) ∘ c = a ∘ (b ∘ c)
   -- is_assoc a b c : op (op a b) c = op a (op b c)
   -- is_assoc (a b c: α) : op (op a b) c = op a (op b c)
   -- is_assoc : op (op a b) c = op a (op b c)
 
 class Monoid (M : Type u) extends Semigroup M where
-  empty: M -- alternative names: identity or unit or ε
-  left_identity: ∀ (a: M), op empty a = a
-  right_identity: ∀ (a: M), op a empty = a
+  id: M -- alternative names: identity or unit or ε
+  left_identity: ∀ (a: M), id ∘ a = a
+  right_identity: ∀ (a: M), a ∘ id = a
 
 namespace algebra_using_structure'
 

--- a/Katydid/Std/AlgebraExamples.lean
+++ b/Katydid/Std/AlgebraExamples.lean
@@ -1,0 +1,85 @@
+import Katydid.Std.Algebra
+import Mathlib.Data.Tree
+
+-- # Examples of Monoids
+
+-- ## Addition is a Monoid
+
+instance : Magma Nat where
+  op a b := a + b
+
+instance : Semigroup Nat where
+  is_assoc := Nat.add_assoc
+
+theorem add_left_identity (a: Nat):
+  0 + a = a := by
+  simp
+
+theorem add_right_identity (a: Nat):
+  a + 0 = a := by
+  simp
+
+instance AddMonoid : Monoid Nat where
+  id := 0
+  left_identity := add_left_identity
+  right_identity := add_right_identity
+
+-- ## Or is a Monoid
+
+instance : Magma Bool where
+  op a b := a || b
+
+theorem bool_or_assoc: ∀ (a b c : Bool), (a || b || c) = (a || (b || c)) := by
+  intro a b c
+  cases a with
+  | false =>
+    simp
+  | true =>
+    simp
+
+instance : Semigroup Bool where
+  is_assoc := bool_or_assoc
+
+instance AnyMonoid : Monoid Bool where
+  id := false
+  left_identity := by simp
+  right_identity := by simp
+
+-- We can write common functions that can be applied to any of these monoids
+
+-- A simple function mconcat, which takes a list of monoid elements and combines them into a single element. Summing a list of integers is now the same as overlaying a list of images.
+def mconcat (m: Monoid α) (xs: List α): α := Id.run <| do
+  let mut res: α := m.id
+  for x in xs do
+    res := res ∘ x
+  return res
+
+def sum (xs: List Nat): Nat :=
+  mconcat AddMonoid xs
+
+def any (xs: List Bool): Bool :=
+  mconcat AnyMonoid xs
+
+#eval sum [0,1,2]
+
+-- A more complex function foldMap can recursively walk over a tree and either: return whether any element is true, find if there is any element is larger than 5, or transform the foldable structure into a set, all depending on the type of monoid we use.
+def foldMap (m: Monoid β) (f: α -> β): Tree α -> β
+  | Tree.nil => Monoid.id
+  | Tree.node a left right =>
+    let b := f a
+    let lb := foldMap m f left
+    let rb := foldMap m f right
+    b ∘ (lb ∘ rb)
+
+def anyTree (t: Tree Bool): Bool :=
+  foldMap AnyMonoid id t
+
+#eval anyTree (Tree.node false Tree.nil Tree.nil)
+#eval anyTree (Tree.node false Tree.nil (Tree.node false (Tree.node true Tree.nil Tree.nil) Tree.nil))
+
+def anyLargerThan (t: Tree Nat) (max: Nat): Bool :=
+  foldMap AnyMonoid (fun x => x > max) t
+
+#eval anyLargerThan (Tree.node 6 Tree.nil Tree.nil) 5
+#eval anyLargerThan (Tree.node 3 Tree.nil (Tree.node 7 (Tree.node 1 Tree.nil Tree.nil) Tree.nil)) 4
+#eval anyLargerThan (Tree.node 3 Tree.nil (Tree.node 7 (Tree.node 1 Tree.nil Tree.nil) Tree.nil)) 8

--- a/Katydid/Std/Ordering.lean
+++ b/Katydid/Std/Ordering.lean
@@ -75,7 +75,7 @@ instance : Semigroup Ordering where
   is_assoc := Ordering.lex_assoc
 
 instance : Monoid Ordering where
-  empty := Ordering.eq
+  id := Ordering.eq
   left_identity := Ordering.lex_left_identity
   right_identity := Ordering.lex_right_identity
 

--- a/Katydid/Std/ThunkOrdering.lean
+++ b/Katydid/Std/ThunkOrdering.lean
@@ -47,7 +47,7 @@ instance : Semigroup (Thunk Ordering) where
   is_assoc := ThunkOrdering.lex_assoc
 
 instance : Monoid (Thunk Ordering) where
-  empty := Ordering.eq
+  id := Ordering.eq
   left_identity := ThunkOrdering.lex_left_identity
   right_identity := ThunkOrdering.lex_right_identity
 


### PR DESCRIPTION
## Proof more theorems on lists

This update all started with trying to prove more theorems on lists
Introducing the linarith tactic seemed like a good idea
This resulted in simplifying quite a few theorems, because simp relies on import magic

## more simp only

I use `simp?` to make theorems more robust for next time we introduce a new import, by copying the output of `simp?` to replace `simp` with a `simp only ...`

## Remove imports of already declared types in Mathlib

I had to remove the following imports, since they are important for our project and they cause errors
```
import Katydid.Std.Algebra
import Katydid.Std.Ordering
import Katydid.Std.ThunkOrdering
```
These causes errors like:
```
./././Katydid.lean:1:0: error: import Katydid.Std.Ordering failed, environment already contains 'instReprOrdering._closed_1._cstage2' from Mathlib.Init.Data.Ordering.Basic
```
and
```
./././Katydid.lean:1:0: error: import Mathlib.Algebra.Group.Defs failed, environment already contains 'Monoid.toSemigroup' from Katydid.Std.Algebra
error: external command `/Users/walterschulze/.elan/toolchains/leanprover--lean4---nightly-2023-07-12/bin/lean` exited with code 1
```

## Add Algebra Examples

We will delete these at some point, but I'll use them in a presentation soon

