### PR TITLE
Add attribute [refl]

### DIFF
--- a/Katydid.lean
+++ b/Katydid.lean
@@ -1,6 +1,7 @@
 import Katydid.Std.Lists
 import Katydid.Std.Ltac
 import Katydid.Std.Balistic
+import Katydid.Std.Tipe
 
 import Katydid.Conal.Language
 import Katydid.Conal.Calculus

--- a/Katydid/Conal/Examples.lean
+++ b/Katydid/Conal/Examples.lean
@@ -6,8 +6,16 @@ import Katydid.Conal.Language
 -- _ : a∪b [ 'b' ]
 -- _ = inj₂ refl
 example : (or_ (char 'a') (char 'b')) ['a'] :=
-  Sum.inl REq.rrefl
+  Sum.inl TEq.rrefl
 
 example : (or_ (char 'a') (char 'b')) ['a'] := by
   apply Sum.inl
   constructor
+
+-- an example showing:
+--   - how to use `simp` for `char`
+--   - how to use `rfl` for `TEq`
+example : (or_ (char 'a') (char 'b')) ['a'] := by
+  apply Sum.inl
+  simp
+  rfl

--- a/Katydid/Conal/Language.lean
+++ b/Katydid/Conal/Language.lean
@@ -1,16 +1,6 @@
+import Katydid.Std.Tipe
+
 open List
-
-/--
-The equality relation. We use this instead of Lean's `Eq` because
-we need it to be defined on Type instead of Prop.
--/
-inductive REq {α : Type u} (x : α) : α -> Type u where
-  | rrefl : REq x x
-
--- open import Data.List.Relation.Unary.All
-inductive All {α: Type u} (P : α -> Type u) : (List α -> Type u)  where
-  | nil : All P []
-  | cons : ∀ {x xs} (_px : P x) (_pxs : All P xs), All P (x :: xs)
 
 -- Lang : Set (suc ℓ)
 -- Lang = A ✶ → Set ℓ
@@ -30,12 +20,12 @@ def universal : Lang α :=
 -- 𝟏 : Lang
 -- 𝟏 w = w ≡ []
 def emptyStr : Lang α :=
-  fun w => REq w []
+  fun w => w ≡ []
 
 -- ` : A → Lang
 -- ` c w = w ≡ [ c ]
 def char (a : α) :=
-  fun w => REq w [a]
+  fun w => w ≡ [a]
 
 -- infixl 7 _·_
 -- _·_ : Set ℓ → Op₁ Lang
@@ -58,13 +48,16 @@ def and_ (P : Lang α) (Q : Lang α) : Lang α :=
 -- infixl 7 _⋆_
 -- _⋆_ : Op₂ Lang
 -- (P ⋆ Q) w = ∃⇃ λ (u ,  v) → (w ≡ u ⊙ v) × P u × Q v
-def concat (P : Lang α) (Q : Lang α) : Lang α :=
+def concat_ (P : Lang α) (Q : Lang α) : Lang α :=
   fun (w : List α) =>
-    Σ (x : List α) (y : List α), (REq w (x ++ y)) × P x × Q y
+    Σ (x : List α) (y : List α), (w ≡ (x ++ y)) × P x × Q y
 
 -- infixl 10 _☆
 -- _☆ : Op₁ Lang
 -- (P ☆) w = ∃ λ ws → (w ≡ concat ws) × All P ws
-def star (P : Lang α) : Lang α :=
+def star_ (P : Lang α) : Lang α :=
   fun (w : List α) =>
-    Σ (ws : List (List α)), (REq w (List.join ws)) × All P ws
+    Σ (ws : List (List α)), (w ≡ (List.join ws)) × All P ws
+
+-- attribute [simp] allows these definitions to be unfolded when using the simp tactic.
+attribute [simp] universal emptySet emptyStr char scalar or_ and_ concat_ star_

--- a/Katydid/Std/Tipe.lean
+++ b/Katydid/Std/Tipe.lean
@@ -17,6 +17,7 @@ inductive TEq {α : Type u} (x : α) : α -> Type u where
 -- the abbreviation ≡ is typed with `slash = =`
 infixl:65 " ≡ " => TEq
 
+-- attribute [refl] allows us to use the rfl tactic on TEq, see the example below.
 attribute [refl] TEq.rrefl
 
 example : 1 ≡ 1 := by rfl

--- a/Katydid/Std/Tipe.lean
+++ b/Katydid/Std/Tipe.lean
@@ -1,0 +1,26 @@
+-- required for `attribute [refl]`
+import Mathlib.Init.Algebra.Classes
+
+-- Tipe is a collection of standard types and functions associated with Type,
+-- that we would expect to be in the Lean standard library at some point in future.
+-- The file is named Tipe, since it is Afrikaans for Type and common way to avoid using the keyword Type, since it has the same pronounciation as type.
+
+-- Discussion where we got the tips for this library: https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/is.20there.20a.20refl.20for.20Type
+
+/--
+The equality relation. We use this instead of Lean's `Eq` because
+we need it to be defined on Type instead of Prop.
+-/
+inductive TEq {α : Type u} (x : α) : α -> Type u where
+  | rrefl : TEq x x
+
+-- the abbreviation ≡ is typed with `slash = =`
+infixl:65 " ≡ " => TEq
+
+attribute [refl] TEq.rrefl
+
+example : 1 ≡ 1 := by rfl
+
+inductive All {α: Type u} (P : α -> Type u) : (List α -> Type u)  where
+  | nil : All P []
+  | cons : ∀ {x xs} (_px : P x) (_pxs : All P xs), All P (x :: xs)

--- a/Katydid/Std/Tipe.lean
+++ b/Katydid/Std/Tipe.lean
@@ -21,6 +21,8 @@ attribute [refl] TEq.rrefl
 
 example : 1 ≡ 1 := by rfl
 
+-- Only the Prop version is available in mathlib https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/List/Defs.html#List.Forall
+-- so we have to create our own version for Type
 inductive All {α: Type u} (P : α -> Type u) : (List α -> Type u)  where
   | nil : All P []
   | cons : ∀ {x xs} (_px : P x) (_pxs : All P xs), All P (x :: xs)

--- a/README.md
+++ b/README.md
@@ -68,5 +68,7 @@ Please check the [prerequisites](https://github.com/katydid/proofs#prerequisites
 
   - Lean4 has exceptional [instructions for installing Lean4 in VS Code](https://github.com/leanprover/lean4/blob/master/doc/quickstart.md).
   - Remember to also add `lake` (the build system for lean) to your `PATH`.  You can do this on mac by adding `export PATH=~/.elan/bin/:${PATH}` to your  `~/.zshrc` file
+  - Use mathlib's cache to speed up building time by running: `$lake exe cache get`
+
 
 


### PR DESCRIPTION
This allows TEq to use rfl tactic

We also moved REq to Std.Tipe and renamed it to TEq
And added an infix symbol \== for TEq, so that it looks closer to the Agda